### PR TITLE
`${VAR:-}` is redundant. Do echo `'$GEM_HOME'`

### DIFF
--- a/renv.sh
+++ b/renv.sh
@@ -4,27 +4,27 @@
 renv() {
   case "$1" in
     status | s)
-      [ -n "${GEM_HOME:-}" ] && echo "GEM_HOME='$GEM_HOME'"
-      [ -n "${GEM_PATH:-}" ] && echo "GEM_PATH='$GEM_PATH'"
-      echo "PATH='$PATH'" && return
+      [ -n "$GEM_HOME" ] && echo "GEM_HOME='$GEM_HOME'"
+      [ -n "$GEM_PATH" ] && echo "GEM_PATH='$GEM_PATH'"
+      echo "PATH='$PATH'"
       ;;
     reset | r)
-      if [ -z "${RENV_ORIG_PATH:-}" ]; then
+      if [ -z "$RENV_ORIG_PATH" ]; then
         echo ">>>> renv not set. Try: 'renv'"
-        return 3
+        return 1
       fi
 
-      if [ -n "${RENV_ORIG_GEM_HOME:-}" ]; then
+      if [ -n "$RENV_ORIG_GEM_HOME" ]; then
         GEM_HOME=$RENV_ORIG_GEM_HOME
       else
         unset GEM_HOME
       fi
-      if [ -n "${RENV_ORIG_GEM_PATH:-}" ]; then
+      if [ -n "$RENV_ORIG_GEM_PATH" ]; then
         GEM_PATH=$RENV_ORIG_GEM_PATH
       else
         unset GEM_PATH
       fi
-      if [ -n "${RENV_ORIG_PATH:-}" ]; then
+      if [ -n "$RENV_ORIG_PATH" ]; then
         PATH=$RENV_ORIG_PATH
       fi
       unset RENV_ORIG_GEM_HOME RENV_ORIG_GEM_PATH RENV_ORIG_PATH
@@ -32,13 +32,13 @@ renv() {
       echo "---> renv is reset, GEM_HOME='${GEM_HOME:-"<unset>"}'."
       ;;
     set | "")
-      if [ -n "${RENV_ORIG_PATH:-}" ]; then
-        echo ">>>> renv is active, GEM_HOME='${GEM_HOME:-}'. Try: 'renv reset'"
-        return 9
+      if [ -n "$RENV_ORIG_PATH" ]; then
+        echo ">>>> renv is active, GEM_HOME='$GEM_HOME'. Try: 'renv reset'"
+        return 1
       fi
       if ! command -v ruby >/dev/null; then
-        echo ">>>> 'ruby' program not found in PATH='${PATH:-}', aborting"
-        return 10
+        echo ">>>> 'ruby' program not found in PATH='$PATH', aborting"
+        return 1
       fi
 
       eval "$(
@@ -51,16 +51,16 @@ renv() {
       # shellcheck disable=SC2154
       local gem_dir="$PWD/.gem/$ruby_engine/$ruby_version"
 
-      export RENV_ORIG_PATH="$PATH"
-      export RENV_ORIG_GEM_HOME="$GEM_HOME"
-      export RENV_ORIG_GEM_PATH="$GEM_PATH"
+      RENV_ORIG_PATH="$PATH"
+      RENV_ORIG_GEM_HOME="$GEM_HOME"
+      RENV_ORIG_GEM_PATH="$GEM_PATH"
 
       export PATH="$gem_dir/bin:$PATH"
       export GEM_HOME="$gem_dir"
       # shellcheck disable=SC2154
       export GEM_PATH="$gem_dir:$gem_path"
 
-      echo "---> renv is set, GEM_HOME={$GEM_HOME}"
+      echo "---> renv is set, GEM_HOME='$GEM_HOME'"
       ;;
     help | h | --help | -h | *)
       echo "usage: renv [help|reset|set|status]"


### PR DESCRIPTION
instead of `{$GEM_HOME}` when setting the env. This was maybe a typo.

No need to export the `RENV_ORIG_*` variables, as they are only used within the same shell session.

Use 1 as error code. See https://tldp.org/LDP/abs/html/exitcodes.html
